### PR TITLE
Remove instanceof check

### DIFF
--- a/lib/section.js
+++ b/lib/section.js
@@ -107,10 +107,6 @@ module.exports = function Section(name, description, types) {
 
         if (arguments.length == 1) {
             section = arguments[0];
-
-            if (!(section instanceof Section))
-                throw new Error("Single argument to mount must be a Section!");
-
             var addRoutes = section.getRoutes();
 
             Object.keys(addRoutes).forEach(function(method) {


### PR DESCRIPTION
This instanceof check was a mistake.
It's problematic when building on top of a transient dependency because we can't access the same Section.

The two-arity code-path does not perform this check either.